### PR TITLE
Getting dagger to work.

### DIFF
--- a/app/src/main/java/com/combustela/combustela/CombustelaApp.kt
+++ b/app/src/main/java/com/combustela/combustela/CombustelaApp.kt
@@ -1,8 +1,5 @@
 package com.combustela.combustela
 
-import android.app.Application
-import com.combustela.combustela.data.db.DbModule
-import com.combustela.combustela.di.app.ApplicationModule
 import com.combustela.combustela.di.app.DaggerApplicationComponent
 import dagger.android.AndroidInjector
 import dagger.android.support.DaggerApplication
@@ -11,7 +8,7 @@ import timber.log.Timber
 class CombustelaApp : DaggerApplication() {
 
     override fun applicationInjector(): AndroidInjector<out DaggerApplication>
-    = DaggerApplicationComponent.builder().application(this).build()
+    = DaggerApplicationComponent.factory().newApplicationComponent(this)
 
 
     override fun onCreate() {

--- a/app/src/main/java/com/combustela/combustela/base/NavigationController.kt
+++ b/app/src/main/java/com/combustela/combustela/base/NavigationController.kt
@@ -2,12 +2,13 @@ package com.combustela.combustela.base
 
 import android.content.Intent
 import android.support.v4.app.FragmentActivity
+import com.combustela.combustela.di.controller.ControllerScope
 import com.combustela.combustela.ui.detail.DetailActivity
 import timber.log.Timber
 import javax.inject.Inject
 
-class NavigationController
-@Inject constructor(val activity: FragmentActivity){
+@ControllerScope
+class NavigationController @Inject constructor(val activity: FragmentActivity) {
 
     fun goDetail(lineaId: String){
         Timber.w("ACTIVITY CLASS IS $activity")

--- a/app/src/main/java/com/combustela/combustela/di/activity/ActivityBinder.kt
+++ b/app/src/main/java/com/combustela/combustela/di/activity/ActivityBinder.kt
@@ -3,7 +3,9 @@ package com.combustela.combustela.di.activity
 import com.combustela.combustela.di.controller.ControllerModule
 import com.combustela.combustela.di.controller.ControllerScope
 import com.combustela.combustela.ui.MainActivity
+import com.combustela.combustela.ui.MainActivityModule
 import com.combustela.combustela.ui.detail.DetailActivity
+import com.combustela.combustela.ui.detail.DetailActivityModule
 import dagger.Module
 import dagger.android.ContributesAndroidInjector
 
@@ -11,10 +13,10 @@ import dagger.android.ContributesAndroidInjector
 abstract class ActivityBinder {
 
     @ControllerScope
-    @ContributesAndroidInjector(modules = [ControllerModule::class])
+    @ContributesAndroidInjector(modules = [ControllerModule::class, MainActivityModule::class])
     abstract fun contributesMainActivity(): MainActivity
 
     @ControllerScope
-    @ContributesAndroidInjector(modules = [ControllerModule::class])
+    @ContributesAndroidInjector(modules = [ControllerModule::class, DetailActivityModule::class])
     abstract fun contributesDetailActivity(): DetailActivity
 }

--- a/app/src/main/java/com/combustela/combustela/di/app/ApplicationComponent.kt
+++ b/app/src/main/java/com/combustela/combustela/di/app/ApplicationComponent.kt
@@ -1,16 +1,14 @@
 package com.combustela.combustela.di.app
 
+import android.app.Application
 import com.combustela.combustela.CombustelaApp
 import com.combustela.combustela.data.db.DbModule
 import com.combustela.combustela.di.activity.ActivityBinder
 import com.combustela.combustela.di.modules.ApiModule
 import com.combustela.combustela.di.modules.RepositoryModule
-import com.combustela.combustela.di.controller.ControllerComponent
-import com.combustela.combustela.di.controller.ControllerModule
 import com.combustela.combustela.di.modules.NetModule
 import dagger.BindsInstance
 import dagger.Component
-import dagger.android.AndroidInjectionModule
 import dagger.android.AndroidInjector
 import dagger.android.support.AndroidSupportInjectionModule
 import javax.inject.Singleton
@@ -29,10 +27,8 @@ import javax.inject.Singleton
 )
 interface ApplicationComponent : AndroidInjector<CombustelaApp> {
 
-    @Component.Builder
-    interface Builder {
-        fun build(): ApplicationComponent
-        @BindsInstance
-        fun application(application: CombustelaApp) : Builder
+    @Component.Factory
+    interface Factory {
+     fun newApplicationComponent(@BindsInstance app: Application): ApplicationComponent
     }
 }

--- a/app/src/main/java/com/combustela/combustela/di/app/ApplicationModule.kt
+++ b/app/src/main/java/com/combustela/combustela/di/app/ApplicationModule.kt
@@ -3,7 +3,6 @@ package com.combustela.combustela.di.app
 import android.app.Application
 import android.content.Context
 import android.net.ConnectivityManager
-import com.combustela.combustela.CombustelaApp
 import com.combustela.combustela.base.net.NetworkInteractor
 import com.combustela.combustela.base.net.NetworkInteractorImpl
 import com.combustela.combustela.base.scheduler.AppSchedulerProvider
@@ -16,10 +15,6 @@ import javax.inject.Singleton
 
 @Module(includes = [ViewModelModule::class])
 class ApplicationModule {
-
-    @Provides
-    @Singleton
-    fun application(app: CombustelaApp): Application = app
 
     @Provides
     fun provideNetworkInteractor(networkInteractor: NetworkInteractorImpl): NetworkInteractor = networkInteractor

--- a/app/src/main/java/com/combustela/combustela/di/controller/ControllerModule.kt
+++ b/app/src/main/java/com/combustela/combustela/di/controller/ControllerModule.kt
@@ -1,32 +1,13 @@
 package com.combustela.combustela.di.controller
 
-import android.content.Context
 import android.support.v4.app.FragmentActivity
-import com.combustela.combustela.base.NavigationController
 import dagger.Module
 import dagger.Provides
-import kotlin.math.acos
 
 @Module
-class ControllerModule(val activity: FragmentActivity) {
-
-
-    @Provides
-    @ControllerScope
-    fun providesContext(): Context = activity
+class ControllerModule {
 
     @Provides
     @ControllerScope
-    fun activity() = activity
-
-
-    @Provides
-    @ControllerScope
-    fun layoutInflater() = activity.layoutInflater
-
-
-    @Provides
-    @ControllerScope
-    fun provideNavigationController(activity: FragmentActivity) = NavigationController(activity)
-
+    fun layoutInflater(activity: FragmentActivity) = activity.layoutInflater
 }

--- a/app/src/main/java/com/combustela/combustela/ui/MainActivityModule.kt
+++ b/app/src/main/java/com/combustela/combustela/ui/MainActivityModule.kt
@@ -1,0 +1,12 @@
+package com.combustela.combustela.ui
+
+import android.support.v4.app.FragmentActivity
+import com.combustela.combustela.di.controller.ControllerScope
+import dagger.Binds
+import dagger.Module
+
+@Module
+abstract class MainActivityModule {
+  @Binds @ControllerScope
+  abstract fun bindsActivity(mainActivity: MainActivity): FragmentActivity
+}

--- a/app/src/main/java/com/combustela/combustela/ui/detail/DetailActivityModule.kt
+++ b/app/src/main/java/com/combustela/combustela/ui/detail/DetailActivityModule.kt
@@ -1,0 +1,13 @@
+package com.combustela.combustela.ui.detail
+
+import android.support.v4.app.FragmentActivity
+import com.combustela.combustela.di.controller.ControllerScope
+import dagger.Binds
+import dagger.Module
+
+@Module
+abstract class DetailActivityModule {
+
+  @Binds @ControllerScope
+  abstract fun bindsActivity(detailActivity: DetailActivity): FragmentActivity
+}

--- a/versions.gradle
+++ b/versions.gradle
@@ -7,7 +7,7 @@ ext {
             'compileSdk'      : 28,
             'buildTools'      : '28.0.0',
             'supportLibrary'  : '28.0.0',
-            'dagger'          : '2.21',
+            'dagger'          : '2.23.2',
 
             'kotlin'          : '1.2.41',
 


### PR DESCRIPTION
The main fixes were installing MainActivityModule and DetailActivityModule on the subcomponent generated by @ContributesAndroidInjector and removing some unnecessary methods in the ControllerModule.

Additional Improvements:
- Bumped Dagger version and using newer, more concise factory API
- Using @Injects instead of provision method for NavigationController
- Removed unnecessary CombustelaApp -> Application provision method by simply passing in the Application in the component factory method 